### PR TITLE
Added prompt_template attribute to GenerationConfig

### DIFF
--- a/libs/vectara/langchain_vectara/vectorstores.py
+++ b/libs/vectara/langchain_vectara/vectorstores.py
@@ -76,6 +76,7 @@ class GenerationConfig(BaseModel):
     max_used_search_results: int = 7
     response_language: str = "eng"
     generation_preset_name: str = "vectara-summary-ext-24-05-med-omni"
+    prompt_template: Optional[str] = None
     enable_factual_consistency_score: bool = True
     citations: Optional[Citation] = None
     model_parameters: Optional[Dict[str, Any]] = Field(default=None)


### PR DESCRIPTION
This PR introduces a `prompt_template` parameter to `GenerationConfig`, allowing users to provide a custom prompt template to generate a response for the retrieved documents.
 
Fixes #6 